### PR TITLE
update the method setSource(byte[] source) 

### DIFF
--- a/docs/java-api/docs/index_.asciidoc
+++ b/docs/java-api/docs/index_.asciidoc
@@ -140,7 +140,7 @@ String json = "{" +
     "}";
 
 IndexResponse response = client.prepareIndex("twitter", "tweet")
-        .setSource(json,XContentType.JSON)
+        .setSource(json, XContentType.JSON)
         .get();
 --------------------------------------------------
 

--- a/docs/java-api/docs/index_.asciidoc
+++ b/docs/java-api/docs/index_.asciidoc
@@ -140,7 +140,7 @@ String json = "{" +
     "}";
 
 IndexResponse response = client.prepareIndex("twitter", "tweet")
-        .setSource(json)
+        .setSource(json,XContentType.JSON)
         .get();
 --------------------------------------------------
 


### PR DESCRIPTION
In ElasticSearch 5.5,the method setSource(byte[]) from the type IndexRequestBuilder is deprecated,use the method setSource(byte[] source,XContentType xContentType).